### PR TITLE
emcee 3.1.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,20 +10,20 @@ source:
   sha256: 8e0e19dc8bcef9c6d02f860bef8ddc6c876b8878a6ce666943e2c5cfd9317fed
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  skip: True  # [py<39]
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
     - setuptools >=40.6.0
     - setuptools-scm
     - wheel
   run:
     - numpy
-    - python >=3.6
+    - python
 
 test:
   imports:
@@ -36,9 +36,15 @@ test:
 about:
   home: https://emcee.readthedocs.io
   summary: The Python ensemble sampling toolkit for MCMC
-  dev_url: https://github.com/dfm/emcee
+  description: |
+    emcee is a stable, well tested Python implementation of the
+    affine-invariant ensemble sampler for Markov chain Monte Carlo (MCMC)
+    proposed by Goodman & Weare (2010).
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  dev_url: https://github.com/dfm/emcee
+  doc_url: https://emcee.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
emcee 3.1.6 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5161](https://anaconda.atlassian.net/browse/PKG-5161) 
- [Upstream repository](https://github.com/dfm/emcee)
- Relevant dependency PRs:
    - https://github.com/AnacondaRecipes/emcee-feedstock/pull/3

### Explanation of changes:

- initial build of 3.1.6, dependency for `smac`


[PKG-5161]: https://anaconda.atlassian.net/browse/PKG-5161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ