### PR TITLE
emcee 3.1.4 [fix py38] :snowflake: 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,8 @@ requirements:
     - setuptools-scm
     - wheel
   run:
-    - numpy
     - python
+    - {{ pin_compatible('numpy') }}
 
 test:
   imports:
@@ -34,6 +34,9 @@ test:
   commands:
     - pip check
     - pytest -v --pyargs emcee
+    # skip test_indexing on osx-64 because numpy version
+    # 'numpy.testing.assert_allclose' introduced in numpy 1.5
+    - pytest -v --pyargs emcee -k "not test_indexing"  # [osx and x86_64]
 
 about:
   home: https://emcee.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: 8e0e19dc8bcef9c6d02f860bef8ddc6c876b8878a6ce666943e2c5cfd9317fed
 
 build:
+  number: 1
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
-  skip: True  # [py<39]
 
 requirements:
   host:
@@ -28,10 +28,12 @@ requirements:
 test:
   imports:
     - emcee
-  commands:
-    - pip check
   requires:
     - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest -v --pyargs emcee
 
 about:
   home: https://emcee.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,9 +34,6 @@ test:
   commands:
     - pip check
     - pytest -v --pyargs emcee
-    # skip test_indexing on osx-64 because numpy version
-    # 'numpy.testing.assert_allclose' introduced in numpy 1.5
-    - pytest -v --pyargs emcee -k "not test_indexing"  # [osx and x86_64]
 
 about:
   home: https://emcee.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy
 
 test:
   imports:


### PR DESCRIPTION
emcee 3.1.4 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5381]
- dev_url (pypi): https://github.com/dfm/emcee/tree/v3.1.4
- conda-forge: https://github.com/conda-forge/emcee-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/emcee/3.1.4
- pypi inspector: https://inspector.pypi.io/project/emcee/3.1.4

### Explanation of changes:

- add py38, add upstream tests, bump build number


[PKG-5381]: https://anaconda.atlassian.net/browse/PKG-5381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ